### PR TITLE
Use latest rust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.51-alpine
+FROM rust:alpine
 MAINTAINER Douile <25043847+Douile@users.noreply.github.com>
 
 LABEL "com.github.actions.name"="Rust Release binary"


### PR DESCRIPTION
According to the [official rust image](https://hub.docker.com/_/rust), using the `alpine` tag gives us the Rust in an Alpine image.

I am specifically interested in using 1.54, as this seems to be [required for the current version of clap](https://github.com/clap-rs/clap/issues/2702#issuecomment-899012811).

As an alternative, I could provide a PR that switches to 1.54, if you prefer to manage versions explicitly.