### PR TITLE
Update Rust to 1.54

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.51-alpine
+FROM rust:1.54-alpine
 MAINTAINER Douile <25043847+Douile@users.noreply.github.com>
 
 LABEL "com.github.actions.name"="Rust Release binary"


### PR DESCRIPTION
1.54 seems to be [required for the current version of clap](https://github.com/clap-rs/clap/issues/2702#issuecomment-899012811).