### PR TITLE
fix openssl lib path from /usr/lib64 to /usr/lib

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -77,7 +77,7 @@ for BINARY in $BINARIES; do
     OUTPUT=$(./build.sh "${CMD_PATH}" "${OUTPUT_DIR}")
   else
     rustup target add "$RUSTTARGET"
-    OPENSSL_LIB_DIR=/usr/lib64 OPENSSL_INCLUDE_DIR=/usr/include/openssl CARGO_TARGET_DIR="./target" cargo build --release --target "$RUSTTARGET" --bin "$BINARY"
+    OPENSSL_LIB_DIR=/usr/lib OPENSSL_INCLUDE_DIR=/usr/include/openssl CARGO_TARGET_DIR="./target" cargo build --release --target "$RUSTTARGET" --bin "$BINARY"
     OUTPUT=$(find "target/${RUSTTARGET}/release/" -maxdepth 1 -type f -executable \( -name "${BINARY}" -o -name "${BINARY}.*" \) -print0 | xargs -0)
   fi
 


### PR DESCRIPTION
Alpine doesn't appear to install the openssl libraries in a lib64
directory anymore, causing it to fail to build rust programs that
require linking against openssl.

```
$ sudo docker run -it --rm rust:1.54-alpine
/ # apk add openssl-dev
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
(1/2) Installing pkgconf (1.7.4-r0)
(2/2) Installing openssl-dev (1.1.1l-r0)
Executing busybox-1.33.1-r3.trigger
OK: 119 MiB in 28 packages
/ # apk info -L openssl-dev | grep lib
usr/lib/libcrypto.so
usr/lib/libssl.so
usr/lib/pkgconfig/libcrypto.pc
usr/lib/pkgconfig/libssl.pc
usr/lib/pkgconfig/openssl.pc
/ # ls /usr/lib64/
ls: /usr/lib64/: No such file or directory
```