### PR TITLE
Support a list of archive types

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ This action will only work when you release a project as it uploads the artifact
 ```bash
 GITHUB_TOKEN  # Must be set to ${{ secrets.GITHUB_TOKEN }} - Allows uploading of artifacts to release
 RUSTTARGET    # The rust target triple, see README for supported triples
-EXTRA_FILES   # Space seperated list of extra files to include in final output
+EXTRA_FILES   # Space separated list of extra files to include in final output
 SRC_DIR       # Relative path to the src dir (directory with Cargo.toml in) from root of project
+ARCHIVE_TYPES # Type(s) of archive(s) to create, e.g. "zip" (default) or "zip tar.gz"; supports: (zip, tar[.gz|.bz2|.xz])
 ```
 
 ## Example

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,9 @@ inputs:
   SRC_DIR:
     description: 'Path to directory containing Cargo.toml (defaults to project root)'
     required: false
+  ARCHIVE_TYPES:
+    description: 'List of archive types to publish the binaries with, default "zip", supports zip and all tar formats'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,6 +26,8 @@ UPLOAD_URL=${UPLOAD_URL/\{?name,label\}/}
 RELEASE_NAME=$(echo "$EVENT_DATA" | jq -r .release.tag_name)
 PROJECT_NAME=$(basename "$GITHUB_REPOSITORY")
 NAME="${NAME:-${PROJECT_NAME}_${RELEASE_NAME}}_${RUSTTARGET}"
+ARCHIVE_TYPES="${ARCHIVE_TYPES:-"zip"}"
+EXTRA_FILES="${EXTRA_FILES:-""}"
 
 if [ -z "${EXTRA_FILES+x}" ]; then
   echo "::warning file=entrypoint.sh::EXTRA_FILES not set"
@@ -43,23 +45,39 @@ fi
 
 FILE_LIST=$(echo "${FILE_LIST}" | awk '{$1=$1};1')
 
-ARCHIVE="tmp.zip"
 echo "::info::Packing files: $FILE_LIST"
-# shellcheck disable=SC2086
-zip -9r $ARCHIVE ${FILE_LIST}
 
-CHECKSUM=$(sha256sum ${ARCHIVE} | cut -d ' ' -f 1)
+for ARCHIVE_TYPE in $ARCHIVE_TYPES; do
+  ARCHIVE="tmp.${ARCHIVE_TYPE}"
 
-curl \
-  -X POST \
-  --data-binary @${ARCHIVE} \
-  -H 'Content-Type: application/octet-stream' \
-  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-  "${UPLOAD_URL}?name=${NAME}.${ARCHIVE/tmp./}"
+  # shellcheck disable=SC2086
+  case $ARCHIVE_TYPE in
+    "zip")
+      zip -9r $ARCHIVE ${FILE_LIST}
+    ;;
 
-curl \
-  -X POST \
-  --data "$CHECKSUM" \
-  -H 'Content-Type: text/plain' \
-  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-  "${UPLOAD_URL}?name=${NAME}.sha256sum"
+    "tar"|"tar.gz"|"tar.bz2"|"tar.xz")
+      tar caf $ARCHIVE ${FILE_LIST}
+    ;;
+
+    *)
+      echo "::error file=entrypoint.sh::The given archive type '${ARCHIVE_TYPE}' is not supported; please choose one of 'zip' or 'tar.gz'"
+      continue
+  esac
+
+  CHECKSUM=$(sha256sum "${ARCHIVE}" | cut -d ' ' -f 1)
+
+  curl \
+    -X POST \
+    --data-binary @"${ARCHIVE}" \
+    -H 'Content-Type: application/octet-stream' \
+    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+    "${UPLOAD_URL}?name=${NAME}.${ARCHIVE/tmp./}"
+
+  curl \
+    -X POST \
+    --data "$CHECKSUM" \
+    -H 'Content-Type: text/plain' \
+    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+    "${UPLOAD_URL}?name=${NAME}.${ARCHIVE/tmp./}.sha256sum"
+done


### PR DESCRIPTION
This changeset introduces `ARCHIVE_TYPES`. The environment variable's default is `zip` to keep the current default behavior as expected. One can use it to set a list of archive types to publish with, e.g. all available types `ARCHIVE_TYPES: "zip tar tar.gz tar.bz2 tar.xz"` would create a release like:

![image](https://user-images.githubusercontent.com/188284/132651454-d054bfb7-6ea3-4775-b314-4baf12ece3e9.png)

Futhermore it contains a bit of boyscouting:
- `EXTRA_FILES` is initialized as empty if not set

---

Fixes #15 