### PR TITLE
Add Mac OS X Compiler Exports 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,6 +47,8 @@ EOF
 ;;
 
 "x86_64-apple-darwin")
+export CC=/opt/osxcross/target/bin/o64-clang
+export CXX=/opt/osxcross/target/bin/o64-clang++
 mkdir -p /.cargo
 cat > /.cargo/config.toml << EOF
 [target.x86_64-apple-darwin]


### PR DESCRIPTION
When cross compiling for `x86_64-apple-darwin`, if any packages require C bindings, then the specific Mac OS X compilers must be used. Closed issues #21 and #25 were actually the result of a failure to cross compile dependency packages with `cc`. This PR exports the location of the `CC` and `CXX` compilers. I have tested this by building the docker image and successfully building for a workflow.