### PR TITLE
Allow the user to specify a TOOLCHAIN_VERSION via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,15 @@ This action will only work when you release a project as it uploads the artifact
 
 ## Environment variables
 ```bash
-GITHUB_TOKEN  # Must be set to ${{ secrets.GITHUB_TOKEN }} - Allows uploading of artifacts to release
-RUSTTARGET    # The rust target triple, see README for supported triples
-EXTRA_FILES   # Space separated list of extra files to include in final output
-SRC_DIR       # Relative path to the src dir (directory with Cargo.toml in) from root of project
-ARCHIVE_TYPES # Type(s) of archive(s) to create, e.g. "zip" (default) or "zip tar.gz"; supports: (zip, tar[.gz|.bz2|.xz])
-PRE_BUILD     # Path to script to run before build e.g. "pre.sh"
-POST_BUILD    # Path to script to run after build e.g. "post.sh"
-MINIFY        # If set to "true", the resulting binary will be stripped and compressed by UPX. ("false" by default)
+GITHUB_TOKEN      # Must be set to ${{ secrets.GITHUB_TOKEN }} - Allows uploading of artifacts to release
+RUSTTARGET        # The rust target triple, see README for supported triples
+EXTRA_FILES       # Space separated list of extra files to include in final output
+SRC_DIR           # Relative path to the src dir (directory with Cargo.toml in) from root of project
+ARCHIVE_TYPES     # Type(s) of archive(s) to create, e.g. "zip" (default) or "zip tar.gz"; supports: (zip, tar[.gz|.bz2|.xz])
+PRE_BUILD         # Path to script to run before build e.g. "pre.sh"
+POST_BUILD        # Path to script to run after build e.g. "post.sh"
+MINIFY            # If set to "true", the resulting binary will be stripped and compressed by UPX. ("false" by default)
+TOOLCHAIN_VERSION # The rust toolchain version to use (see https://rust-lang.github.io/rustup/concepts/toolchains.html#toolchain-specification)
 ```
 
 ## Examples

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ inputs:
   POST_BUILD:
     description: 'Relative path of script to run after building'
     required: false
+  TOOLCHAIN_VERSION:
+    description: "The rust toolchain version to use (see https://rust-lang.github.io/rustup/concepts/toolchains.html#toolchain-specification)"
+    required: false
 runs:
   using: 'docker'
   image: 'docker://ghcr.io/rust-build/rust-build.action:v1.2.5'

--- a/build.sh
+++ b/build.sh
@@ -68,9 +68,9 @@ esac
 info "Setting up toolchain"
 TOOLCHAIN_VERSION="${TOOLCHAIN_VERSION:-""}"
 if [ "$TOOLCHAIN_VERSION" != "" ]; then
-  rustup default "$TOOLCHAIN_VERSION"
+  rustup default "$TOOLCHAIN_VERSION" >&2
 fi
-rustup target add "$RUSTTARGET"
+rustup target add "$RUSTTARGET" >&2
 
 
 BINARIES="$(cargo read-manifest | jq -r ".targets[] | select(.kind[] | contains(\"bin\")) | .name")"
@@ -82,7 +82,7 @@ for BINARY in $BINARIES; do
   if [ -x "./build.sh" ]; then
     OUTPUT=$(./build.sh "${CMD_PATH}" "${OUTPUT_DIR}")
   else
-    OPENSSL_LIB_DIR=/usr/lib OPENSSL_INCLUDE_DIR=/usr/include/openssl CARGO_TARGET_DIR="./target" cargo build --release --target "$RUSTTARGET" --bin "$BINARY"
+    OPENSSL_LIB_DIR=/usr/lib OPENSSL_INCLUDE_DIR=/usr/include/openssl CARGO_TARGET_DIR="./target" cargo build --release --target "$RUSTTARGET" --bin "$BINARY" >&2
     OUTPUT=$(find "target/${RUSTTARGET}/release/" -maxdepth 1 -type f -executable \( -name "${BINARY}" -o -name "${BINARY}.*" \) -print0 | xargs -0)
   fi
 

--- a/build.sh
+++ b/build.sh
@@ -65,6 +65,14 @@ exit 1
 ;;
 esac
 
+info "Setting up toolchain"
+TOOLCHAIN_VERSION="${TOOLCHAIN_VERSION:-""}"
+if [ "$TOOLCHAIN_VERSION" != "" ]; then
+  rustup default "$TOOLCHAIN_VERSION"
+fi
+rustup target add "$RUSTTARGET"
+
+
 BINARIES="$(cargo read-manifest | jq -r ".targets[] | select(.kind[] | contains(\"bin\")) | .name")"
 
 OUTPUT_LIST=""
@@ -74,7 +82,6 @@ for BINARY in $BINARIES; do
   if [ -x "./build.sh" ]; then
     OUTPUT=$(./build.sh "${CMD_PATH}" "${OUTPUT_DIR}")
   else
-    rustup target add "$RUSTTARGET"
     OPENSSL_LIB_DIR=/usr/lib OPENSSL_INCLUDE_DIR=/usr/include/openssl CARGO_TARGET_DIR="./target" cargo build --release --target "$RUSTTARGET" --bin "$BINARY"
     OUTPUT=$(find "target/${RUSTTARGET}/release/" -maxdepth 1 -type f -executable \( -name "${BINARY}" -o -name "${BINARY}.*" \) -print0 | xargs -0)
   fi


### PR DESCRIPTION
This allows specifying the rust version to be used (as well as nightly
versions) when calling the action.

Closes #35