### PR TITLE
Add support for zstd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL "maintainer"="Douile <25043847+Douile@users.noreply.github.com>"
 
 # Add regular dependencies
 RUN apk add --no-cache curl=7.83.1-r3 jq=1.6-r1 git=2.36.3-r0 build-base=0.5-r3 bash=5.1.16-r2 \
-  zip=3.0-r9 xz=5.2.5-r1 upx=3.96-r1
+  zip=3.0-r9 tar=1.34-r0 xz=5.2.5-r1 zstd=1.5.2-r1 upx=3.96-r1
 
 # Add windows dependencies
 RUN apk add --no-cache mingw-w64-gcc=11.3.0-r0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.60-alpine
+FROM rust:1.64-alpine
 
 LABEL "name"="Automate publishing Rust build artifacts for GitHub releases through GitHub Actions"
 LABEL "version"="1.3.2"
@@ -6,18 +6,15 @@ LABEL "repository"="http://github.com/rust-build/rust-build.action"
 LABEL "maintainer"="Douile <25043847+Douile@users.noreply.github.com>"
 
 # Add regular dependencies
-RUN apk add --no-cache curl=7.80.0-r1 jq=1.6-r1 git=2.34.2-r0 build-base=0.5-r2 bash=5.1.16-r0 \
-  zip=3.0-r9 upx=3.96-r1
+RUN apk add --no-cache curl=7.83.1-r3 jq=1.6-r1 git=2.36.3-r0 build-base=0.5-r3 bash=5.1.16-r2 \
+  zip=3.0-r9 xz=5.2.5-r1 upx=3.96-r1
 
 # Add windows dependencies
-RUN apk add --no-cache mingw-w64-gcc=11.2.0-r0
-
-# Add emscripten dependencies
-RUN apk add --no-cache emscripten-fastcomp=1.40.1-r1
+RUN apk add --no-cache mingw-w64-gcc=11.3.0-r0
 
 # Add apple dependencies
-RUN apk add --no-cache clang=12.0.1-r1 cmake=3.21.3-r0 libxml2-dev=2.9.13-r0 \
-  openssl-dev=1.1.1n-r0 fts-dev=1.2.7-r1 bsd-compat-headers=0.7.2-r3 xz=5.2.5-r1
+RUN apk add --no-cache clang=13.0.1-r1 cmake=3.23.1-r0 libxml2-dev=2.9.14-r2 \
+  openssl-dev=1.1.1q-r0 fts-dev=1.2.7-r1 bsd-compat-headers=0.7.2-r3
 RUN git clone https://github.com/tpoechtrager/osxcross /opt/osxcross
 RUN curl -Lo /opt/osxcross/tarballs/MacOSX10.10.sdk.tar.xz "https://s3.dockerproject.org/darwin/v2/MacOSX10.10.sdk.tar.xz"
 RUN ["/bin/bash", "-c", "cd /opt/osxcross && UNATTENDED=yes OSX_VERSION_MIN=10.8 ./build.sh"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ GITHUB_TOKEN      # Must be set to ${{ secrets.GITHUB_TOKEN }} - Allows uploadin
 RUSTTARGET        # The rust target triple, see README for supported triples
 EXTRA_FILES       # Space separated list of extra files to include in final output
 SRC_DIR           # Relative path to the src dir (directory with Cargo.toml in) from root of project
-ARCHIVE_TYPES     # Type(s) of archive(s) to create, e.g. "zip" (default) or "zip tar.gz"; supports: (zip, tar[.gz|.bz2|.xz])
+ARCHIVE_TYPES     # Type(s) of archive(s) to create, e.g. "zip" (default) or "zip tar.gz"; supports: (zip, tar.[gz|bz2|xz|zst])
 ARCHIVE_NAME      # Full name of archive to upload (you must specify file extension and change this if building multiple targets)
 PRE_BUILD         # Path to script to run before build e.g. "pre.sh"
 POST_BUILD        # Path to script to run after build e.g. "post.sh"
@@ -54,7 +54,8 @@ jobs:
 ```
 
 ### Build windows, linux and mac with native zip types
-Will build native binaries for windows, linux and mac. Windows will upload as zip, linux as .tar.gz and .tar.xz, mac as .zip.
+Will build native binaries for windows, linux and mac. Windows will upload as .zip, linux as .tar.gz, .tar.xz and
+.tar.zst, and mac as .zip.
 ```yml
 # .github/workflows/release.yml
 
@@ -73,7 +74,7 @@ jobs:
           - target: x86_64-pc-windows-gnu
             archive: zip
           - target: x86_64-unknown-linux-musl
-            archive: tar.gz tar.xz
+            archive: tar.gz tar.xz tar.zst
           - target: x86_64-apple-darwin
             archive: zip
     steps:

--- a/build.sh
+++ b/build.sh
@@ -42,14 +42,6 @@ exit 1
 ;;
 
 "wasm32-wasi") ;;
-"wasm32-unknown-emscripten") 
-mkdir -p /.cargo
-cat > /.cargo/config.toml << EOF
-[target.wasm32-unknown-emscripten]
-linker = "/usr/lib/emscripten-fastcomp/bin/clang"
-ar = "/usr/lib/emscripten-fastcomp/bin/llvm-ar"
-EOF
-;;
 
 "x86_64-apple-darwin")
 export CC=/opt/osxcross/target/bin/o64-clang

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -93,12 +93,12 @@ for ARCHIVE_TYPE in $ARCHIVE_TYPES; do
       zip -9r $ARCHIVE ${FILE_LIST}
     ;;
 
-    "tar"|"tar.gz"|"tar.bz2"|"tar.xz")
+    "tar"|"tar.gz"|"tar.bz2"|"tar.xz"|"tar.zst")
       tar caf $ARCHIVE ${FILE_LIST}
     ;;
 
     *)
-      error "The given archive type '${ARCHIVE_TYPE}' is not supported; please choose one of 'zip' or 'tar.gz'"
+      error "The given archive type '${ARCHIVE_TYPE}' is not supported; please use a supported archive type."
       continue
   esac
 


### PR DESCRIPTION
This PR adds support for the zstd archive format.

It also updated the docker image and dependencies (that's the first commit).

This also remove target `wasm32-unknown-emscripten`: it was not documented and
the `emscripten-fastcomp` package is no longer available in alpine 3.16.