### PR TITLE
Bump rust to 1.64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.60-alpine
+FROM rust:1.64-alpine
 
 LABEL "name"="Automate publishing Rust build artifacts for GitHub releases through GitHub Actions"
 LABEL "version"="1.3.2"


### PR DESCRIPTION
This fixes a problem with required Rust version of 1.61+ for many projects.