### PR TITLE
deps: Bump Rust version to 1.64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.60-alpine
+FROM rust:1.64-alpine
 
 LABEL "name"="Automate publishing Rust build artifacts for GitHub releases through GitHub Actions"
 LABEL "version"="1.3.2"


### PR DESCRIPTION
I currently can't use this action to publish a package that depends on `minijinja`, because it requires Rust 1.61. I can't think of any downside to bumping the action to use current Rust.