### PR TITLE
Replace deprecated ::set-output with new env variable

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@
 set -eu
 
 set_output() {
-  echo "::set-output name=$1::$2"
+  echo "$1=$2" >> $GITHUB_OUTPUT
 }
 info() {
   echo "::info::$*"


### PR DESCRIPTION
This PR replaces Github's old and deprecated ::set-output method with new environmental variable system, in this case setting $GITHUB_OUTPUT.