### PR TITLE
build.sh: export pkg_config_path

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -79,7 +79,7 @@ for BINARY in $BINARIES; do
   if [ -x "./build.sh" ]; then
     OUTPUT=$(./build.sh "${CMD_PATH}" "${OUTPUT_DIR}")
   else
-    OPENSSL_LIB_DIR=/usr/lib OPENSSL_INCLUDE_DIR=/usr/include/openssl CARGO_TARGET_DIR="./target" cargo build --release --target "$RUSTTARGET" --bin "$BINARY" >&2
+    OPENSSL_LIB_DIR=/usr/lib OPENSSL_INCLUDE_DIR=/usr/include/openssl PKG_CONFIG_PATH=/usr/lib/pkgconfig CARGO_TARGET_DIR="./target" cargo build --release --target "$RUSTTARGET" --bin "$BINARY" >&2
     OUTPUT=$(find "target/${RUSTTARGET}/release/" -maxdepth 1 -type f -executable \( -name "${BINARY}" -o -name "${BINARY}.*" \) -print0 | xargs -0)
   fi
 


### PR DESCRIPTION
On Linux, some dependencies are resolved by `pkg-config --libs --cflags $lib`.
For example we have an application here that requires the `yeslogic-fontconfig-sys` package, which resolves its "fontconfig" definition on linux with that command. 
As of today, the `cargo build` step would fail due to an empty `PKG_CONFIG_PATH` env. variable.
Example of error logs: [right here](https://github.com/gwbres/rinex/actions/runs/3592158271/jobs/6047541280)

Signed-off-by: Guillaume W. Bres <guillaume.bressaix@gmail.com>