### PR TITLE
Update .hadolint.yaml - DL3018

### DIFF
--- a/.github/linters/.hadolint.yaml
+++ b/.github/linters/.hadolint.yaml
@@ -1,3 +1,4 @@
 override:
   style:
     - DL3059
+    - DL3018


### PR DESCRIPTION
To ignore those lines:

* Dockerfile:9 DL3018 warning: Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`
* Dockerfile:12 DL3018 warning: Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`
* Dockerfile:15 DL3018 warning: Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`