### PR TITLE
Statically link librarys when building to fix OpenSSL

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -79,7 +79,7 @@ for BINARY in $BINARIES; do
   if [ -x "./build.sh" ]; then
     OUTPUT=$(./build.sh "${CMD_PATH}" "${OUTPUT_DIR}")
   else
-    OPENSSL_LIB_DIR=/usr/lib OPENSSL_INCLUDE_DIR=/usr/include/openssl PKG_CONFIG_PATH=/usr/lib/pkgconfig CARGO_TARGET_DIR="./target" cargo build --release --target "$RUSTTARGET" --bin "$BINARY" >&2
+    OPENSSL_LIB_DIR=/usr/lib OPENSSL_INCLUDE_DIR=/usr/include/openssl PKG_CONFIG_PATH=/usr/lib/pkgconfig CARGO_TARGET_DIR="./target" RUSTFLAGS="-C target-feature=-crt-static" cargo build --release --target "$RUSTTARGET" --bin "$BINARY" >&2
     OUTPUT=$(find "target/${RUSTTARGET}/release/" -maxdepth 1 -type f -executable \( -name "${BINARY}" -o -name "${BINARY}.*" \) -print0 | xargs -0)
   fi
 


### PR DESCRIPTION
This is required for OpenSSL to work properly when building on Alpine, otherwise a segmentation fault will occur.

https://github.com/sfackler/rust-openssl/issues/1462
https://github.com/est31/cargo-udeps/issues/89

It seems the solution to this issue is to add `RUSTFLAGS="-C target-feature=-crt-static"`. Another solution would be allowing the user to set their own RUSTFLAGS however I'm not experienced enough with bash and github actions to create and test it. 

This would also fix #66 and #49.