### PR TITLE
Fix build on x86_64-unknown-linux-musl because of missing zlib.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL "repository"="http://github.com/rust-build/rust-build.action"
 LABEL "maintainer"="Douile <25043847+Douile@users.noreply.github.com>"
 
 # Add regular dependencies
-RUN apk add --no-cache curl jq git build-base bash zip tar xz zstd upx
+RUN apk add --no-cache curl jq git build-base bash zip tar xz zstd upx zlib-static
 
 # Add windows dependencies
 RUN apk add --no-cache mingw-w64-gcc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.76.0-alpine3.19
+FROM rust:1.82-alpine3.20
 
 LABEL "name"="Automate publishing Rust build artifacts for GitHub releases through GitHub Actions"
 LABEL "version"="1.4.5"


### PR DESCRIPTION
The failure was:

```
  = note: /usr/lib/gcc/x86_64-alpine-linux-musl/13.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find -lz: No such file or directory
          collect2: error: ld returned 1 exit status
```

This PR also updates rust and alpine.

For my future reference. To test builds locally do

```
docker build -t dev-rust-build.action . && docker run  -e GITHUB_REPOSITORY=orium/cargo-rdme -e GITHUB_WORKSPACE=/rust/build/workspace -e RUSTTARGET=x86_64-unknown-linux-musl -v ~/programming/projects/cargo-rdme/:/rust/build/workspace -ti --entrypoint /bin/bash dev-rust-build.action
```

Closes #100