### PR TITLE
fix: avoid 'dubious ownership' issues with git repo.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,6 +61,9 @@ rmdir "$PROJECT_ROOT"
 ln -s "$GITHUB_WORKSPACE" "$PROJECT_ROOT"
 cd "$PROJECT_ROOT"
 
+# Avoid 'dubious ownership' errors from some `git` subcommands:
+git config --global safe.directory "$GITHUB_WORKSPACE"
+
 # Run pre-build script
 if [ -f "$PRE_BUILD" ]; then
   "./$PRE_BUILD"


### PR DESCRIPTION
The `git` command performs some ownership checks on the '.git' directory which may lead to some `git` subcommands used by various build tools (most notably `rev-parse`) refusing to execute.

This patch avoids the issue by explicitly marking the entire '$GITHUB_WORKSPACE' path as safe to `git`.